### PR TITLE
Do not panic on temporary resolution failure

### DIFF
--- a/golang/internal_resolver.go
+++ b/golang/internal_resolver.go
@@ -23,19 +23,19 @@ type internalResolver struct {
 	stop      chan struct{}
 }
 
-func newInternalResolver(ctx context.Context, service string, namespace string, notify chan struct{}) *internalResolver {
+func newInternalResolver(ctx context.Context, service string, namespace string, notify chan struct{}) (*internalResolver, error) {
 	var r internalResolver
 	r.addresses = make(map[string]bool)
 	r.ctx = ctx
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	informer := cache.NewSharedIndexInformer(
@@ -87,7 +87,7 @@ func newInternalResolver(ctx context.Context, service string, namespace string, 
 
 	r.informer = informer
 
-	return &r
+	return &r, nil
 }
 
 func (r *internalResolver) start(wg *sync.WaitGroup) {


### PR DESCRIPTION
## Short Note on UpdateState
#### UpdateState updates the state of the ClientConn appropriately.

If an error is returned, the resolver should try to resolve the
target again. The resolver should use a backoff timer to prevent
overloading the server with requests. If a resolver is certain that
reresolving will not change the result, e.g. because it is
a watch-based resolver, returned errors can be ignored.

If the resolved State is the same as the last reported one, calling
UpdateState can be omitted.

**a watch-based resolver, returned errors can be ignored**
